### PR TITLE
Remove extensive use of :: and patching of Object class

### DIFF
--- a/lib/plotrb.rb
+++ b/lib/plotrb.rb
@@ -2,22 +2,15 @@ require 'yajl'
 require 'json'
 require 'uri'
 
-require_relative 'plotrb/base'
+require 'plotrb/base'
 
-require_relative 'plotrb/data'
-require_relative 'plotrb/transforms'
-require_relative 'plotrb/scales'
-require_relative 'plotrb/marks'
-require_relative 'plotrb/axes'
-require_relative 'plotrb/kernel'
-require_relative 'plotrb/visualization'
+require 'plotrb/data'
+require 'plotrb/transforms'
+require 'plotrb/scales'
+require 'plotrb/marks'
+require 'plotrb/axes'
+require 'plotrb/kernel'
+require 'plotrb/visualization'
 
 module Plotrb
-
-end
-
-class Object
-
-  include ::Plotrb::Kernel
-
 end

--- a/lib/plotrb/axes.rb
+++ b/lib/plotrb/axes.rb
@@ -5,13 +5,13 @@ module Plotrb
   # See {https://github.com/trifacta/vega/wiki/Axes}
   class Axis
 
-    include ::Plotrb::Base
+    include Plotrb::Base
 
     TYPES = %i(x y)
 
     TYPES.each do |t|
       define_singleton_method(t) do |&block|
-        ::Plotrb::Axis.new(t, &block)
+        Plotrb::Axis.new(t, &block)
       end
     end
 
@@ -77,7 +77,7 @@ module Plotrb
         alias_method :with_grid?, :grid?
       }
       self.instance_eval(&block) if block_given?
-      ::Plotrb::Kernel.axes << self
+      Plotrb::Kernel.axes << self
       self
     end
 
@@ -115,7 +115,7 @@ module Plotrb
       @properties ||= {}
       return @properties unless element
       @properties.merge!(
-          element.to_sym => ::Plotrb::Mark::MarkProperty.new(:text, &block)
+          element.to_sym => Plotrb::Mark::MarkProperty.new(:text, &block)
       )
       self
     end
@@ -156,10 +156,10 @@ module Plotrb
       return unless @scale
       case @scale
         when String
-          unless ::Plotrb::Kernel.find_scale(@scale)
+          unless Plotrb::Kernel.find_scale(@scale)
             raise ArgumentError, 'Scale not found'
           end
-        when ::Plotrb::Scale
+        when Plotrb::Scale
           @scale = @scale.name
         else
           raise ArgumentError, 'Unknown Scale'

--- a/lib/plotrb/data.rb
+++ b/lib/plotrb/data.rb
@@ -4,7 +4,7 @@ module Plotrb
   # See {https://github.com/trifacta/vega/wiki/Data}
   class Data
 
-    include ::Plotrb::Base
+    include Plotrb::Base
 
     # @!attributes name
     #   @return [String] the name of the data set
@@ -27,7 +27,7 @@ module Plotrb
         alias_method :file, :url
       }
       self.instance_eval(&block) if block_given?
-      ::Plotrb::Kernel.data << self
+      Plotrb::Kernel.data << self
       self
     end
 
@@ -36,7 +36,7 @@ module Plotrb
         when 0
           @format
         when 1
-          @format = ::Plotrb::Data::Format.new(args[0].to_sym, &block)
+          @format = Plotrb::Data::Format.new(args[0].to_sym, &block)
           self
         else
           raise ArgumentError, 'Invalid Data format'
@@ -76,7 +76,7 @@ module Plotrb
       if @name.nil? || @name.strip.empty?
         raise ArgumentError, 'Name missing for Data object'
       end
-      if ::Plotrb::Kernel.duplicate_data?(@name)
+      if Plotrb::Kernel.duplicate_data?(@name)
         raise ArgumentError, 'Duplicate names for Data object'
       end
     end
@@ -101,10 +101,10 @@ module Plotrb
       return unless @source
       case source
         when String
-          unless ::Plotrb::Kernel.find_data(@source)
+          unless Plotrb::Kernel.find_data(@source)
             raise ArgumentError, 'Source Data not found'
           end
-        when ::Plotrb::Data
+        when Plotrb::Data
           @source = @source.name
         else
           raise ArgumentError, 'Unknown Data source'
@@ -129,7 +129,7 @@ module Plotrb
 
     class Format
 
-      include ::Plotrb::Base
+      include Plotrb::Base
 
       add_attributes :type
 

--- a/lib/plotrb/kernel.rb
+++ b/lib/plotrb/kernel.rb
@@ -58,47 +58,47 @@ module Plotrb
       @transforms ||= []
     end
 
-    # Initialize ::Plotrb::Visualization object
+    # Initialize Plotrb::Visualization object
 
     def visualization(&block)
-      ::Plotrb::Visualization.new(&block)
+      Plotrb::Visualization.new(&block)
     end
 
-    # Initialize ::Plotrb::Data objects
+    # Initialize Plotrb::Data objects
 
     def pdata(&block)
-      ::Plotrb::Data.new(&block)
+      Plotrb::Data.new(&block)
     end
 
     def method_missing(method, *args, &block)
       case method.to_s
         when /^(\w)_axis$/
-          # Initialize ::Plotrb::Axis objects
-          if ::Plotrb::Axis::TYPES.include?($1.to_sym)
+          # Initialize Plotrb::Axis objects
+          if Plotrb::Axis::TYPES.include?($1.to_sym)
             cache_method($1, 'axis')
             self.send(method)
           else
             super
           end
         when /^(\w+)_scale$/
-          # Initialize ::Plotrb::Scale objects
-          if ::Plotrb::Scale::TYPES.include?($1.to_sym)
+          # Initialize Plotrb::Scale objects
+          if Plotrb::Scale::TYPES.include?($1.to_sym)
             cache_method($1, 'scale')
             self.send(method)
           else
             super
           end
         when /^(\w+)_transform$/
-          # Initialize ::Plotrb::Transform objects
-          if ::Plotrb::Transform::TYPES.include?($1.to_sym)
+          # Initialize Plotrb::Transform objects
+          if Plotrb::Transform::TYPES.include?($1.to_sym)
             cache_method($1, 'transform')
             self.send(method)
           else
             super
           end
         when /^(\w+)_mark$/
-          # Initialize ::Plotrb::Mark objects
-          if ::Plotrb::Mark::TYPES.include?($1.to_sym)
+          # Initialize Plotrb::Mark objects
+          if Plotrb::Mark::TYPES.include?($1.to_sym)
             cache_method($1, 'mark')
             self.send(method)
           else
@@ -116,7 +116,7 @@ module Plotrb
         define_method("#{type}_#{klass}") do |&block|
           # class names are constants
           # create shortcut methods to initialize Plotrb objects
-          ::Kernel::const_get("::Plotrb::#{klass.capitalize}").
+          Kernel::const_get("::Plotrb::#{klass.capitalize}").
               new(type.to_sym, &block)
         end
       }

--- a/lib/plotrb/marks.rb
+++ b/lib/plotrb/marks.rb
@@ -4,14 +4,14 @@ module Plotrb
   # See {https://github.com/trifacta/vega/wiki/Marks}
   class Mark
 
-    include ::Plotrb::Base
+    include Plotrb::Base
 
     # all available types of marks defined by Vega
     TYPES = %i(rect symbol path arc area line image text group)
 
     TYPES.each do |t|
       define_singleton_method(t) do |&block|
-        ::Plotrb::Mark.new(t, &block)
+        Plotrb::Mark.new(t, &block)
       end
     end
 
@@ -48,7 +48,7 @@ module Plotrb
         add_attributes(:scales, :axes, :marks)
         define_multi_val_attributes(:scales, :axes, :marks)
       end
-      ::Plotrb::Kernel.marks << self
+      Plotrb::Kernel.marks << self
       self.instance_eval(&block) if block_given?
       self
     end
@@ -65,7 +65,7 @@ module Plotrb
       process_from
       data = @from[:data] if @from
       @properties.merge!(
-          { enter: ::Plotrb::Mark::MarkProperty.
+          { enter: Plotrb::Mark::MarkProperty.
               new(@type, data, &block) }
       )
       self
@@ -75,7 +75,7 @@ module Plotrb
       process_from
       data = @from[:data] if @from
       @properties.merge!(
-          { exit: ::Plotrb::Mark::MarkProperty.
+          { exit: Plotrb::Mark::MarkProperty.
               new(@type, data, &block) }
       )
       self
@@ -85,7 +85,7 @@ module Plotrb
       process_from
       data = @from[:data] if @from
       @properties.merge!(
-          { update: ::Plotrb::Mark::MarkProperty.
+          { update: Plotrb::Mark::MarkProperty.
               new(@type, data, &block) }
       )
       self
@@ -95,7 +95,7 @@ module Plotrb
       process_from
       data = @from[:data] if @from
       @properties.merge!(
-          { hover: ::Plotrb::Mark::MarkProperty.
+          { hover: Plotrb::Mark::MarkProperty.
               new(@type, data, &block) }
       )
       self
@@ -111,7 +111,7 @@ module Plotrb
 
     def process_name
       return unless @name
-      if ::Plotrb::Kernel.duplicate_mark?(@name)
+      if Plotrb::Kernel.duplicate_mark?(@name)
         raise ArgumentError, 'Duplicate Mark name'
       end
     end
@@ -122,14 +122,14 @@ module Plotrb
       @from.each do |f|
         case f
           when String
-            if ::Plotrb::Kernel.find_data(f)
+            if Plotrb::Kernel.find_data(f)
               from[:data] = f
             else
               raise ArgumentError, 'Invalid data for Mark from'
             end
-          when ::Plotrb::Data
+          when Plotrb::Data
             from[:data] = f.name
-          when ::Plotrb::Transform
+          when Plotrb::Transform
             from[:transform] ||= []
             from[:transform] << f
           else
@@ -159,7 +159,7 @@ module Plotrb
 
     class MarkProperty
 
-      include ::Plotrb::Base
+      include Plotrb::Base
 
       # Shared visual properties
 
@@ -326,7 +326,7 @@ module Plotrb
       def define_single_val_attribute(method)
         define_singleton_method(method) do |*args, &block|
           if block
-            val = ::Plotrb::Mark::MarkProperty::ValueRef.
+            val = Plotrb::Mark::MarkProperty::ValueRef.
                 new(@data, *args, &block)
             self.instance_variable_set("@#{method}", val)
           else
@@ -334,7 +334,7 @@ module Plotrb
               when 0
                 self.instance_variable_get("@#{method}")
               when 1
-                val = ::Plotrb::Mark::MarkProperty::ValueRef.new(@data, args[0])
+                val = Plotrb::Mark::MarkProperty::ValueRef.new(@data, args[0])
                 self.instance_variable_set("@#{method}", val)
               else
                 raise ArgumentError
@@ -351,7 +351,7 @@ module Plotrb
       # A value reference specifies the value for a given mark property
       class ValueRef
 
-        include ::Plotrb::Base
+        include Plotrb::Base
 
         # @!attributes value
         #   @return A constant value
@@ -417,10 +417,10 @@ module Plotrb
           return unless @scale
           case @scale
             when String
-              unless ::Plotrb::Kernel.find_scale(@scale)
+              unless Plotrb::Kernel.find_scale(@scale)
                 raise ArgumentError, 'Invalid value scale'
               end
-            when ::Plotrb::Scale
+            when Plotrb::Scale
               @scale = @scale.name
             when Hash
               if @scale[:field]
@@ -438,7 +438,7 @@ module Plotrb
           data = if @data.is_a?(::Plotrb::Data)
                    @data
                  else
-                   ::Plotrb::Kernel.find_data(@data)
+                   Plotrb::Kernel.find_data(@data)
                  end
           extra_fields = (data.extra_fields if data) || []
           if field.to_s.start_with?('data.')

--- a/lib/plotrb/scales.rb
+++ b/lib/plotrb/scales.rb
@@ -5,13 +5,13 @@ module Plotrb
   # See {https://github.com/trifacta/vega/wiki/Scales}
   class Scale
 
-    include ::Plotrb::Base
+    include Plotrb::Base
 
     TYPES = %i(linear log pow sqrt quantile quantize threshold ordinal time utc)
 
     TYPES.each do |t|
       define_singleton_method(t) do |&block|
-        ::Plotrb::Scale.new(t, &block)
+        Plotrb::Scale.new(t, &block)
       end
     end
 
@@ -36,7 +36,7 @@ module Plotrb
           set_quantitative_scale_attributes
       end
       set_common_scale_attributes
-      ::Plotrb::Kernel.scales << self
+      Plotrb::Kernel.scales << self
       self.instance_eval(&block) if block_given?
       self
     end
@@ -180,7 +180,7 @@ module Plotrb
       if @name.nil? || @name.strip.empty?
         raise ArgumentError, 'Name missing for Scale object'
       end
-      if ::Plotrb::Kernel.duplicate_scale?(@name)
+      if Plotrb::Kernel.duplicate_scale?(@name)
         raise ArgumentError, 'Duplicate names for Scale object'
       end
     end
@@ -196,7 +196,7 @@ module Plotrb
       case @domain
         when String
           @domain = get_data_ref_from_string(@domain)
-        when ::Plotrb::Data
+        when Plotrb::Data
           @domain = get_data_ref_from_data(@domain)
         when Array
           if @domain.all? { |d| is_data_ref?(d) }
@@ -205,7 +205,7 @@ module Plotrb
           else
             # leave as it is
           end
-        when ::Plotrb::Scale::DataRef
+        when Plotrb::Scale::DataRef
           # leave as it is
         else
           raise ArgumentError, 'Unsupported Scale domain type'
@@ -218,7 +218,7 @@ module Plotrb
       case @domain_min
         when String
           @domain_min = get_data_ref_from_string(@domain_min)
-        when ::Plotrb::Data
+        when Plotrb::Data
           @domain_min = get_data_ref_from_data(@domain_min)
         when Array
           if @domain_min.all? { |d| is_data_ref?(d) }
@@ -240,7 +240,7 @@ module Plotrb
       case @domain_max
         when String
           @domain_max = get_data_ref_from_string(@domain_max)
-        when ::Plotrb::Data
+        when Plotrb::Data
           @domain_max = get_data_ref_from_data(@domain_max)
         when Array
           if @domain_max.all? { |d| is_data_ref?(d) }
@@ -258,36 +258,36 @@ module Plotrb
 
     def get_data_ref_from_string(ref)
       source, field = ref.split('.', 2)
-      data = ::Plotrb::Kernel.find_data(source)
+      data = Plotrb::Kernel.find_data(source)
       if field.nil?
         if data && data.values.is_a?(Array)
-          ::Plotrb::Scale::DataRef.new.data(source).field('data')
+          Plotrb::Scale::DataRef.new.data(source).field('data')
         else
-          ::Plotrb::Scale::DataRef.new.data(source).field('index')
+          Plotrb::Scale::DataRef.new.data(source).field('index')
         end
       elsif field == 'index'
-        ::Plotrb::Scale::DataRef.new.data(source).field('index')
+        Plotrb::Scale::DataRef.new.data(source).field('index')
       else
         if data.extra_fields.include?(field.to_sym)
-          ::Plotrb::Scale::DataRef.new.data(source).field(field)
+          Plotrb::Scale::DataRef.new.data(source).field(field)
         else
-          ::Plotrb::Scale::DataRef.new.data(source).field("data.#{field}")
+          Plotrb::Scale::DataRef.new.data(source).field("data.#{field}")
         end
       end
     end
 
     def get_data_ref_from_data(data)
       if data.values.is_a?(Array)
-        ::Plotrb::Scale::DataRef.new.data(data.name).field('data')
+        Plotrb::Scale::DataRef.new.data(data.name).field('data')
       else
-        ::Plotrb::Scale::DataRef.new.data(data.name).field('index')
+        Plotrb::Scale::DataRef.new.data(data.name).field('index')
       end
     end
 
     def is_data_ref?(ref)
       return false unless ref.is_a?(String)
       source, _ = ref.split('.', 2)
-      not ::Plotrb::Kernel.find_data(source).nil?
+      not Plotrb::Kernel.find_data(source).nil?
     end
 
     def process_range
@@ -318,7 +318,7 @@ module Plotrb
     # A data reference specifies the field for a given scale property
     class DataRef
 
-      include ::Plotrb::Base
+      include Plotrb::Base
 
       # @!attributes data
       #   @return [String] the name of a data set

--- a/lib/plotrb/simple.rb
+++ b/lib/plotrb/simple.rb
@@ -28,8 +28,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #++
 
-require 'plotrb'
-
 module Plotrb
   module Simple
 

--- a/lib/plotrb/transforms.rb
+++ b/lib/plotrb/transforms.rb
@@ -5,7 +5,7 @@ module Plotrb
   # See {https://github.com/trifacta/vega/wiki/Data-Transforms}
   class Transform
 
-    include ::Plotrb::Base
+    include Plotrb::Base
 
     # all available types of transforms defined by Vega
     TYPES = %i(array copy cross facet filter flatten fold formula slice sort
@@ -14,7 +14,7 @@ module Plotrb
 
     TYPES.each do |t|
       define_singleton_method(t) do |&block|
-        ::Plotrb::Transform.new(t, &block)
+        Plotrb::Transform.new(t, &block)
       end
     end
 
@@ -27,7 +27,7 @@ module Plotrb
       @extra_fields = [:index, :data]
       self.send(@type)
       self.instance_eval(&block) if block_given?
-      ::Plotrb::Kernel.transforms << self
+      Plotrb::Kernel.transforms << self
       self
     end
 
@@ -445,10 +445,10 @@ module Plotrb
       return unless @type == :cross && @with
       case @with
         when String
-          unless ::Plotrb::Kernel.find_data(@with)
+          unless Plotrb::Kernel.find_data(@with)
             raise ArgumentError, 'Invalid data for cross transform'
           end
-        when ::Plotrb::Data
+        when Plotrb::Data
           @with = @with.name
         else
           raise ArgumentError, 'Invalid data for cross transform'
@@ -580,7 +580,7 @@ module Plotrb
           else
             "data.#{field}"
           end
-        when ::Plotrb::Data
+        when Plotrb::Data
           'data'
         else
           raise ArgumentError, 'Invalid data field'

--- a/lib/plotrb/visualization.rb
+++ b/lib/plotrb/visualization.rb
@@ -4,8 +4,8 @@ module Plotrb
   # See {https://github.com/trifacta/vega/wiki/Visualization}
   class Visualization
 
-    include ::Plotrb::Base
-    include ::Plotrb::Kernel
+    include Plotrb::Base
+    include Plotrb::Kernel
 
     # @!attributes name
     #   @return [String] the name of the visualization

--- a/spec/plotrb/axes_spec.rb
+++ b/spec/plotrb/axes_spec.rb
@@ -1,8 +1,8 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
 describe 'Axis' do
 
-  subject { ::Plotrb::Axis.new(:x) }
+  subject { Plotrb::Axis.new(:x) }
 
   describe '#type' do
 
@@ -21,7 +21,7 @@ describe 'Axis' do
     end
 
     it 'sets the scale backing the axis by the scale object' do
-      scale = ::Plotrb::Scale.new.name('foo_scale')
+      scale = Plotrb::Scale.new.name('foo_scale')
       subject.from(scale)
       subject.send(:process_scale)
       subject.scale.should == 'foo_scale'
@@ -29,7 +29,7 @@ describe 'Axis' do
 
     it 'raises error if scale is not found' do
       subject.from('foo_scale')
-      ::Plotrb::Kernel.stub(:find_scale).and_return(nil)
+      Plotrb::Kernel.stub(:find_scale).and_return(nil)
       expect { subject.send(:process_scale) }.to raise_error(ArgumentError)
     end
 

--- a/spec/plotrb/base_spec.rb
+++ b/spec/plotrb/base_spec.rb
@@ -1,9 +1,9 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
 describe 'Base' do
 
   class FooClass
-    include ::Plotrb::Base
+    include Plotrb::Base
   end
 
   class BarClass
@@ -14,7 +14,7 @@ describe 'Base' do
 
   describe 'ClassMethods' do
 
-    let(:foo) { Class.new { include ::Plotrb::Base } }
+    let(:foo) { Class.new { include Plotrb::Base } }
 
     describe '.attributes' do
 
@@ -268,7 +268,7 @@ describe 'Base' do
 
   describe '#classify' do
 
-    let(:foo) { Class.new { extend ::Plotrb::Base } }
+    let(:foo) { Class.new { extend Plotrb::Base } }
 
     it 'classifies string' do
       foo.classify('visualization').should == 'Visualization'

--- a/spec/plotrb/data_spec.rb
+++ b/spec/plotrb/data_spec.rb
@@ -1,8 +1,8 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
 describe 'Data' do
 
-  subject { ::Plotrb::Data.new }
+  subject { Plotrb::Data.new }
 
   describe '#name' do
 
@@ -21,7 +21,7 @@ describe 'Data' do
     end
 
     it 'raises error if name is not unique' do
-      ::Plotrb::Kernel.stub(:duplicate_data?).and_return(false)
+      Plotrb::Kernel.stub(:duplicate_data?).and_return(false)
       expect { subject.send(:process_name) }.to raise_error(ArgumentError)
     end
 
@@ -30,7 +30,7 @@ describe 'Data' do
   describe '#format' do
 
     it 'sets format as a new Format instance' do
-      ::Plotrb::Data::Format.should_receive(:new).with(:foo)
+      Plotrb::Data::Format.should_receive(:new).with(:foo)
       subject.format(:foo)
     end
 
@@ -68,13 +68,13 @@ describe 'Data' do
     end
 
     it 'raises error if source does not exist' do
-      ::Plotrb::Kernel.stub(:find_data).and_return(false)
+      Plotrb::Kernel.stub(:find_data).and_return(false)
       subject.source('foo')
       expect { subject.send(:process_source) }.to raise_error ArgumentError
     end
 
     it 'gets the name of the existing data object' do
-      foo = ::Plotrb::Data.new.name('foo')
+      foo = Plotrb::Data.new.name('foo')
       subject.source(foo)
       subject.send(:process_source)
       subject.source.should == 'foo'
@@ -113,7 +113,7 @@ describe 'Data' do
 
     class Bar; end
 
-    let(:foo) { ::Plotrb::Transform.new(:array) }
+    let(:foo) { Plotrb::Transform.new(:array) }
     let(:bar) { Bar.new }
 
     it 'sets transform if a transform object is given' do
@@ -145,12 +145,12 @@ describe 'Data' do
   describe 'Format' do
 
     it 'raises error if format type is not recognized' do
-      expect { ::Plotrb::Data::Format.new(:foo) }.to raise_error ArgumentError
+      expect { Plotrb::Data::Format.new(:foo) }.to raise_error ArgumentError
     end
 
     context 'json' do
 
-      subject { ::Plotrb::Data::Format.new(:json) }
+      subject { Plotrb::Data::Format.new(:json) }
 
       it 'has parse and property attributes' do
         subject.attributes.should match_array([:type, :parse, :property])
@@ -215,7 +215,7 @@ describe 'Data' do
 
     context 'csv' do
 
-      subject { ::Plotrb::Data::Format.new(:csv) }
+      subject { Plotrb::Data::Format.new(:csv) }
 
       it 'has parse attribute' do
         subject.attributes.should match_array([:type, :parse])
@@ -225,7 +225,7 @@ describe 'Data' do
 
     context 'tsv' do
 
-      subject { ::Plotrb::Data::Format.new(:tsv) }
+      subject { Plotrb::Data::Format.new(:tsv) }
 
       it 'has parse attribute' do
         subject.attributes.should match_array([:type, :parse])
@@ -235,7 +235,7 @@ describe 'Data' do
 
     context 'topojson' do
 
-      subject { ::Plotrb::Data::Format.new(:topojson) }
+      subject { Plotrb::Data::Format.new(:topojson) }
 
       it 'has feature and mesh attribute' do
         subject.attributes.should match_array([:type, :feature, :mesh])
@@ -245,7 +245,7 @@ describe 'Data' do
 
     context 'treejson' do
 
-      subject { ::Plotrb::Data::Format.new(:treejson) }
+      subject { Plotrb::Data::Format.new(:treejson) }
 
       it 'has parse and children attribute' do
         subject.attributes.should match_array([:type, :parse, :children])

--- a/spec/plotrb/kernel_spec.rb
+++ b/spec/plotrb/kernel_spec.rb
@@ -1,9 +1,9 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
 describe 'Kernel' do
 
   class Object
-    include ::Plotrb::Kernel
+    include Plotrb::Kernel
   end
 
   describe '#visualization' do

--- a/spec/plotrb/marks_spec.rb
+++ b/spec/plotrb/marks_spec.rb
@@ -1,14 +1,14 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
 describe 'Mark' do
 
-  subject { ::Plotrb::Mark.rect }
+  subject { Plotrb::Mark.rect }
 
   describe '#initialize' do
 
     context 'when type is group' do
 
-      subject { ::Plotrb::Mark.group }
+      subject { Plotrb::Mark.group }
 
       it 'has additional scales, axes, and marks attribute' do
         subject.attributes.should include(:scales, :axes, :marks)
@@ -21,7 +21,7 @@ describe 'Mark' do
   describe 'properties' do
 
     it 'allows multiple properties' do
-      ::Plotrb::Kernel.stub(:find_data).with('some_data').and_return(true)
+      Plotrb::Kernel.stub(:find_data).with('some_data').and_return(true)
       subject.from('some_data')
       subject.enter
       subject.exit
@@ -33,9 +33,9 @@ describe 'Mark' do
   describe '#from' do
 
     it 'recognizes Data and Transform objects' do
-      foo = ::Plotrb::Transform.facet
-      bar = ::Plotrb::Transform.filter
-      ::Plotrb::Kernel.stub(:find_data).with('some_data').and_return(true)
+      foo = Plotrb::Transform.facet
+      bar = Plotrb::Transform.filter
+      Plotrb::Kernel.stub(:find_data).with('some_data').and_return(true)
       subject.from('some_data', foo, bar)
       subject.send(:process_from)
       subject.from.should == {:data => 'some_data', :transform => [foo, bar]}

--- a/spec/plotrb/scales_spec.rb
+++ b/spec/plotrb/scales_spec.rb
@@ -1,8 +1,8 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
 describe 'Scale' do
 
-  subject { ::Plotrb::Scale.new }
+  subject { Plotrb::Scale.new }
 
   describe '#name' do
 
@@ -13,7 +13,7 @@ describe 'Scale' do
 
     it 'raises error if the name is not unique' do
       subject.name 'foo'
-      ::Plotrb::Kernel.stub(:duplicate_scale?).and_return(true)
+      Plotrb::Kernel.stub(:duplicate_scale?).and_return(true)
       expect { subject.send(:process_name) }.to raise_error(ArgumentError)
     end
 
@@ -32,12 +32,12 @@ describe 'Scale' do
     context 'when domain is a string reference to a data source' do
 
       before(:each) do
-        ::Plotrb::Kernel.stub(:find_data).and_return(::Plotrb::Data.new)
+        Plotrb::Kernel.stub(:find_data).and_return(::Plotrb::Data.new)
       end
 
       it 'separates data source and data field' do
         subject.from('some_data.some_field')
-        ::Plotrb::Data.any_instance.stub(:extra_fields).and_return([])
+        Plotrb::Data.any_instance.stub(:extra_fields).and_return([])
         subject.send(:process_domain)
         subject.domain.data.should == 'some_data'
         subject.domain.field.should == 'data.some_field'
@@ -45,7 +45,7 @@ describe 'Scale' do
 
       it 'defaults field to index if not provided' do
         subject.from('some_data')
-        ::Plotrb::Data.any_instance.stub(:extra_fields).and_return([])
+        Plotrb::Data.any_instance.stub(:extra_fields).and_return([])
         subject.send(:process_domain)
         subject.domain.data.should == 'some_data'
         subject.domain.field.should == 'index'
@@ -53,7 +53,7 @@ describe 'Scale' do
 
       it 'deals with index field properly' do
         subject.from('some_data.index')
-        ::Plotrb::Data.any_instance.stub(:extra_fields).and_return([])
+        Plotrb::Data.any_instance.stub(:extra_fields).and_return([])
         subject.send(:process_domain)
         subject.domain.data.should == 'some_data'
         subject.domain.field.should == 'index'
@@ -61,7 +61,7 @@ describe 'Scale' do
 
       it 'recognizes extra fields added by transform' do
         subject.from('some_data.field')
-        ::Plotrb::Data.any_instance.stub(:extra_fields).and_return([:field])
+        Plotrb::Data.any_instance.stub(:extra_fields).and_return([:field])
         subject.send(:process_domain)
         subject.domain.data.should == 'some_data'
         subject.domain.field.should == 'field'
@@ -142,7 +142,7 @@ describe 'Scale' do
 
     context 'when scale is time or utc' do
 
-      subject { ::Plotrb::Scale.time }
+      subject { Plotrb::Scale.time }
 
       it 'sets valid nice literal' do
         subject.in_seconds
@@ -158,7 +158,7 @@ describe 'Scale' do
 
     context 'when scale is quantitative' do
 
-      subject { ::Plotrb::Scale.linear }
+      subject { Plotrb::Scale.linear }
 
       it 'sets nice to true' do
         subject.nicely

--- a/spec/plotrb/transforms_spec.rb
+++ b/spec/plotrb/transforms_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
 describe 'Transform' do
 
@@ -51,7 +51,7 @@ describe 'Transform' do
 
     it 'raises error if the secondary data does not exist' do
       subject.with('foo')
-      ::Plotrb::Kernel.stub(:find_data).and_return(nil)
+      Plotrb::Kernel.stub(:find_data).and_return(nil)
       expect { subject.send(:process_cross_with) }.to raise_error(ArgumentError)
     end
 

--- a/spec/plotrb/visualization_spec.rb
+++ b/spec/plotrb/visualization_spec.rb
@@ -1,11 +1,11 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
-describe 'Visualization', :broken => true do
+describe 'Visualization', broken: true do
 
   context 'properties' do
 
-    before(:each) do
-      @vis = ::Plotrb::Visualization.new
+    before :each do
+      @vis = Plotrb::Visualization.new
     end
 
     it 'sets name' do
@@ -14,7 +14,7 @@ describe 'Visualization', :broken => true do
     end
 
     it 'raises error when name is nil' do
-      expect { @vis.name = nil }.to raise_error ::Plotrb::InvalidInputError
+      expect { @vis.name = nil }.to raise_error Plotrb::InvalidInputError
     end
 
     it 'sets width when given' do
@@ -27,7 +27,7 @@ describe 'Visualization', :broken => true do
     end
 
     it 'raises error when width is not a number' do
-      expect { @vis.width = [:foo] }.to raise_error ::Plotrb::InvalidInputError
+      expect { @vis.width = [:foo] }.to raise_error Plotrb::InvalidInputError
     end
 
     it 'sets height when given' do
@@ -40,7 +40,7 @@ describe 'Visualization', :broken => true do
     end
 
     it 'raises error when height is not a number' do
-      expect { @vis.height = [:foo] }.to raise_error ::Plotrb::InvalidInputError
+      expect { @vis.height = [:foo] }.to raise_error Plotrb::InvalidInputError
     end
 
     it 'sets viewport when given as an array' do
@@ -54,13 +54,13 @@ describe 'Visualization', :broken => true do
     end
 
     it 'sets viewport to default width and height when not given' do
-      vis = ::Plotrb::Visualization.new(:width => 300, :height => 400)
+      vis = Plotrb::Visualization.new(:width => 300, :height => 400)
       vis.viewport.should == [300, 400]
     end
 
     it 'raises error when viewport contains nil' do
       expect { @vis.viewport = [100, :foo] }.
-          to raise_error ::Plotrb::InvalidInputError
+          to raise_error Plotrb::InvalidInputError
     end
 
     it 'sets padding when given as an integer' do
@@ -79,13 +79,13 @@ describe 'Visualization', :broken => true do
 
     it 'raises error when any padding value is missing' do
       expect { @vis.padding = {:top => 4} }.
-          to raise_error ::Plotrb::InvalidInputError
+          to raise_error Plotrb::InvalidInputError
     end
 
     it 'raises error when any padding value is not a number' do
       expect { @vis.padding = {
           :top => 4, :left => :foo, :right => 'bar', :bottom => nil
-      } }.to raise_error ::Plotrb::InvalidInputError
+      } }.to raise_error Plotrb::InvalidInputError
     end
 
   end

--- a/spec/plotrb_spec.rb
+++ b/spec/plotrb_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe 'Plotrb' do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,6 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rspec'
 require 'plotrb'
 
-# Requires supporting files with custom matchers and macros, etc,
-# in ./support/ and its subdirectories.
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
-
 RSpec.configure do |config|
-  config.filter_run_excluding :broken => true
+  config.filter_run_excluding broken: true
 end


### PR DESCRIPTION
My opinion is that the `class Object` patching is not good practice and the extensive use of `::` makes the code harder to read, it already feels a bit more complex then it perhaps should be. It's not in line with common Ruby best practices.

Although this is a minor patch, maybe this is a step in the right direction, code that's easier to read.
