### PR TITLE
Transform now accepts symbol in addition to string.

### DIFF
--- a/lib/plotrb/transforms.rb
+++ b/lib/plotrb/transforms.rb
@@ -574,6 +574,8 @@ module Plotrb
 
     def get_full_field_ref(field)
       case field
+        when Symbol
+          "data.#{field}"
         when String
           if field.start_with?('data.') || extra_fields.include?(field.to_sym)
             field


### PR DESCRIPTION
Fixes the `ArgumentError` raised by this gist: https://gist.github.com/mohawkjohn/11053241
