### PR TITLE
issue #19

### DIFF
--- a/lib/plotrb/base.rb
+++ b/lib/plotrb/base.rb
@@ -141,6 +141,7 @@ module Plotrb
     end
 
     def classify(name, format=nil)
+      return unless name
       klass = name.to_s.split('_').collect(&:capitalize).join
       if format == :json
         klass[0].downcase + klass[1..-1]
@@ -178,6 +179,7 @@ module Plotrb
       end
 
       def classify(name, format=nil)
+        return unless name
         klass = name.to_s.split('_').collect(&:capitalize).join
         if format == :json
           klass[0].downcase + klass[1..-1]

--- a/lib/plotrb/marks.rb
+++ b/lib/plotrb/marks.rb
@@ -446,7 +446,7 @@ module Plotrb
           elsif extra_fields.include?(field.to_s.split('.')[0].to_sym)
             classify(field, :json)
           else
-            "data.#{field}"
+            "data.#{classify(field, :json)}"
           end
         end
 

--- a/lib/plotrb/scales.rb
+++ b/lib/plotrb/scales.rb
@@ -258,6 +258,7 @@ module Plotrb
 
     def get_data_ref_from_string(ref)
       source, field = ref.split('.', 2)
+      field = classify(field, :json)
       data = ::Plotrb::Kernel.find_data(source)
       if field.nil?
         if data && data.values.is_a?(Array)
@@ -278,9 +279,9 @@ module Plotrb
 
     def get_data_ref_from_data(data)
       if data.values.is_a?(Array)
-        ::Plotrb::Scale::DataRef.new.data(data.name).field('data')
+        ::Plotrb::Scale::DataRef.new.data(classify(data.name)).field('data')
       else
-        ::Plotrb::Scale::DataRef.new.data(data.name).field('index')
+        ::Plotrb::Scale::DataRef.new.data(classify(data.name)).field('index')
       end
     end
 

--- a/spec/plotrb/base_spec.rb
+++ b/spec/plotrb/base_spec.rb
@@ -282,6 +282,11 @@ describe 'Base' do
       foo.classify('foo_bar_baz', :json).should == 'fooBarBaz'
     end
 
+    it 'classifies zero-length and nil string correctly' do
+      foo.classify('').should == ''
+      foo.classify(nil).should == nil
+    end
+
   end
 
   describe 'Hash' do

--- a/spec/plotrb/scales_spec.rb
+++ b/spec/plotrb/scales_spec.rb
@@ -40,7 +40,7 @@ describe 'Scale' do
         ::Plotrb::Data.any_instance.stub(:extra_fields).and_return([])
         subject.send(:process_domain)
         subject.domain.data.should == 'some_data'
-        subject.domain.field.should == 'data.some_field'
+        subject.domain.field.should == 'data.someField'
       end
 
       it 'defaults field to index if not provided' do


### PR DESCRIPTION
wrote one of possible problem solutions - added calls to ::Plotrb::Base.classify method to Mark and Scale classes (to camelcase field names), fixed tests. Another solution would be to remove classify methods from base.rb completely (it turned out that this method also downcases first letter, so after removing camelcase problem remains until this is also removed, thus making classify method useless).
